### PR TITLE
Create spectroscopy results dashboard

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,42 +1,354 @@
 #root {
-  max-width: 1280px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 3rem 2.5rem 4rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: #e2e8f0;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.header h1 {
+  margin: 0.25rem 0 0.75rem;
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.14);
+  color: #38bdf8;
+  margin: 0;
+}
+
+.lede {
+  margin: 0;
+  max-width: 620px;
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+
+.selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 220px;
+}
+
+.selector label {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.selector select {
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  font-size: 1rem;
+  backdrop-filter: blur(6px);
+}
+
+.selector select:focus {
+  outline: 2px solid #38bdf8;
+  border-color: #38bdf8;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+}
+
+.panel {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.panel h2,
+.panel h3 {
+  margin: 0;
+  color: #f1f5f9;
+}
+
+.panel-chart {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.panel-header h2 {
+  font-size: 1.6rem;
+}
+
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}
+
+.metadata span {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.panel-summary {
+  margin: 0;
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+
+.spectral-chart {
+  width: 100%;
+  overflow: hidden;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.12);
+  padding: 0.5rem;
+}
+
+.spectral-chart svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.chart-surface {
+  fill: rgba(148, 163, 184, 0.05);
+  stroke: rgba(148, 163, 184, 0.12);
+  stroke-width: 1;
+}
+
+.grid line {
+  stroke: rgba(148, 163, 184, 0.12);
+  stroke-dasharray: 4 6;
+  shape-rendering: crispEdges;
+}
+
+.axes line {
+  stroke: rgba(148, 163, 184, 0.3);
+  stroke-width: 1.4;
+}
+
+.tick-label {
+  fill: #cbd5f5;
+  font-size: 0.7rem;
+}
+
+.tick-label-x {
+  text-anchor: middle;
+}
+
+.tick-label-y {
+  text-anchor: end;
+}
+
+.axis-label {
+  fill: #e2e8f0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.peaks .peak-marker {
+  stroke: rgba(248, 113, 113, 0.55);
+  stroke-dasharray: 3 6;
+}
+
+.peaks .peak-dot {
+  fill: #f472b6;
+  stroke: rgba(248, 113, 113, 0.8);
+  stroke-width: 2;
+}
+
+.peaks .peak-label {
+  fill: #fda4af;
+  font-size: 0.65rem;
+  text-anchor: middle;
+  font-weight: 600;
+}
+
+.panel-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+  margin: 0;
+}
+
+.details-grid div {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 0.85rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.details-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(148, 163, 184, 0.8);
+  margin-bottom: 0.35rem;
+}
+
+.details-grid dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.quality {
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quality-high {
+  background: rgba(52, 211, 153, 0.18);
+  color: #34d399;
+}
+
+.quality-research-grade {
+  background: rgba(129, 140, 248, 0.2);
+  color: #818cf8;
+}
+
+.quality-pass {
+  background: rgba(250, 204, 21, 0.18);
+  color: #facc15;
+}
+
+.peak-highlights h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.peak-highlights ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.peak-highlights li {
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.peak-wavelength {
+  font-weight: 600;
+  color: #f8fafc;
+  margin-right: 0.5rem;
+}
+
+.peak-intensity {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.peak-highlights p {
+  margin: 0.35rem 0 0;
+  color: #cbd5f5;
+  line-height: 1.4;
+}
+
+.panel-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.panel-table th,
+.panel-table td {
+  padding: 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.panel-table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.panel-table tbody tr.active {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.panel-table tbody tr:hover {
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  #root {
+    padding: 2.5rem 1.5rem 3rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .header {
+    align-items: flex-start;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .panel {
+    padding: 1.5rem;
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,34 +1,417 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useId, useMemo, useState } from 'react'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
+const SPECTRA = [
+  {
+    id: 'chlorophyll-extract',
+    name: 'Chlorophyll Extract',
+    project: 'Leaf Pigment Stability Week 4',
+    collectedOn: '2024-04-18',
+    solvent: '90% acetone',
+    temperature: '22 °C',
+    instrument: 'Shimadzu UV-2600 UV-Vis',
+    normalization: 'Absorbance normalized to 1 cm cuvette path length',
+    summary:
+      'Strong Soret band near 430 nm with a secondary Q-band at 662 nm indicating intact chlorophyll a with minor pheophytinization.',
+    spectrum: [
+      { wavelength: 390, intensity: 0.18 },
+      { wavelength: 410, intensity: 0.36 },
+      { wavelength: 430, intensity: 0.92 },
+      { wavelength: 450, intensity: 0.58 },
+      { wavelength: 470, intensity: 0.36 },
+      { wavelength: 500, intensity: 0.42 },
+      { wavelength: 550, intensity: 0.30 },
+      { wavelength: 600, intensity: 0.54 },
+      { wavelength: 630, intensity: 0.74 },
+      { wavelength: 650, intensity: 0.82 },
+      { wavelength: 662, intensity: 0.87 },
+      { wavelength: 680, intensity: 0.78 },
+      { wavelength: 700, intensity: 0.46 },
+    ],
+    peaks: [
+      { wavelength: 430, intensity: 0.92, assignment: 'Soret transition (π→π*)' },
+      { wavelength: 662, intensity: 0.87, assignment: 'Qy transition, chlorophyll a' },
+    ],
+    quality: 'High',
+  },
+  {
+    id: 'anthocyanin',
+    name: 'Anthocyanin Fraction',
+    project: 'Berry Pigment Profiling',
+    collectedOn: '2024-04-22',
+    solvent: 'Methanol + 0.1% HCl',
+    temperature: '20 °C',
+    instrument: 'Thermo Scientific Evolution 350',
+    normalization: 'Baseline corrected to blank solvent at 540 nm',
+    summary:
+      'Dominant λmax at 526 nm consistent with cyanidin-based anthocyanins. Subtle shoulder in the blue region indicates co-pigmentation.',
+    spectrum: [
+      { wavelength: 380, intensity: 0.12 },
+      { wavelength: 400, intensity: 0.21 },
+      { wavelength: 430, intensity: 0.35 },
+      { wavelength: 460, intensity: 0.48 },
+      { wavelength: 490, intensity: 0.64 },
+      { wavelength: 510, intensity: 0.82 },
+      { wavelength: 526, intensity: 0.95 },
+      { wavelength: 540, intensity: 0.88 },
+      { wavelength: 560, intensity: 0.74 },
+      { wavelength: 600, intensity: 0.46 },
+      { wavelength: 640, intensity: 0.28 },
+      { wavelength: 680, intensity: 0.16 },
+    ],
+    peaks: [
+      { wavelength: 526, intensity: 0.95, assignment: 'π→π* transition, cyanidin derivatives' },
+      { wavelength: 460, intensity: 0.48, assignment: 'Blue co-pigmentation shoulder' },
+    ],
+    quality: 'Research grade',
+  },
+  {
+    id: 'protein-aromatic',
+    name: 'Protein Aromatic Residues',
+    project: 'Protein Folding Monitoring',
+    collectedOn: '2024-04-26',
+    solvent: 'Phosphate buffer pH 7.4',
+    temperature: '25 °C',
+    instrument: 'Jasco J-815 CD with absorption detector',
+    normalization: 'Absorbance scaled to molar extinction at 280 nm',
+    summary:
+      'Tryptophan band centered near 280 nm with phenylalanine shoulder around 258 nm. No scattering artifacts observed.',
+    spectrum: [
+      { wavelength: 240, intensity: 0.20 },
+      { wavelength: 250, intensity: 0.32 },
+      { wavelength: 258, intensity: 0.44 },
+      { wavelength: 265, intensity: 0.52 },
+      { wavelength: 275, intensity: 0.68 },
+      { wavelength: 280, intensity: 0.94 },
+      { wavelength: 290, intensity: 0.88 },
+      { wavelength: 300, intensity: 0.64 },
+      { wavelength: 310, intensity: 0.42 },
+      { wavelength: 320, intensity: 0.30 },
+    ],
+    peaks: [
+      { wavelength: 280, intensity: 0.94, assignment: 'Tryptophan π→π*' },
+      { wavelength: 258, intensity: 0.44, assignment: 'Phenylalanine ring transition' },
+    ],
+    quality: 'Pass',
+  },
+]
+
+const xTicks = [
+  240, 260, 280, 300, 320, 340, 360, 380, 400, 420, 440, 460, 480, 500, 520, 540, 560, 580, 600,
+  620, 640, 660, 680, 700
+]
+
+function SpectralChart({ spectrum, peaks, title }) {
+  const width = 640
+  const height = 280
+  const padding = { top: 20, right: 20, bottom: 40, left: 48 }
+  const titleId = useId()
+
+  const minWavelength = Math.min(...spectrum.map((point) => point.wavelength))
+  const maxWavelength = Math.max(...spectrum.map((point) => point.wavelength))
+  const maxIntensity = Math.max(...spectrum.map((point) => point.intensity))
+
+  const toX = (wavelength) => {
+    return (
+      padding.left +
+      ((wavelength - minWavelength) / (maxWavelength - minWavelength)) *
+        (width - padding.left - padding.right)
+    )
+  }
+
+  const toY = (intensity) => {
+    return (
+      height -
+      padding.bottom -
+      (intensity / maxIntensity) * (height - padding.top - padding.bottom)
+    )
+  }
+
+  const pathD = spectrum
+    .map((point, index) => {
+      const prefix = index === 0 ? 'M' : 'L'
+      return `${prefix}${toX(point.wavelength)},${toY(point.intensity)}`
+    })
+    .join(' ')
+
+  const areaPath = `${pathD} L${toX(spectrum[spectrum.length - 1].wavelength)},${
+    height - padding.bottom
+  } L${toX(spectrum[0].wavelength)},${height - padding.bottom} Z`
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <figure className="spectral-chart" aria-labelledby={titleId}>
+      <figcaption id={titleId} className="sr-only">
+        {title}
+      </figcaption>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`${title}. Peak intensity ${maxIntensity.toFixed(2)} absorbance units.`}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <defs>
+          <linearGradient id="spectrum-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
+            <stop offset="0%" stopColor="#38bdf8" />
+            <stop offset="50%" stopColor="#a855f7" />
+            <stop offset="100%" stopColor="#f472b6" />
+          </linearGradient>
+          <linearGradient id="fill-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.6" />
+            <stop offset="100%" stopColor="#0f172a" stopOpacity="0" />
+          </linearGradient>
+          <radialGradient id="grid-bg">
+            <stop offset="0%" stopColor="#0f172a" stopOpacity="0.05" />
+            <stop offset="100%" stopColor="#0f172a" stopOpacity="0.3" />
+          </radialGradient>
+        </defs>
+        <rect
+          x={padding.left}
+          y={padding.top}
+          width={width - padding.left - padding.right}
+          height={height - padding.top - padding.bottom}
+          fill="url(#grid-bg)"
+          className="chart-surface"
+        />
+        <g className="grid">
+          {xTicks
+            .filter((tick) => tick > minWavelength && tick < maxWavelength)
+            .map((tick) => (
+              <line
+                key={tick}
+                x1={toX(tick)}
+                x2={toX(tick)}
+                y1={padding.top}
+                y2={height - padding.bottom}
+              />
+            ))}
+          {[0.25, 0.5, 0.75, 1].map((fraction) => (
+            <line
+              key={fraction}
+              x1={padding.left}
+              x2={width - padding.right}
+              y1={toY(maxIntensity * fraction)}
+              y2={toY(maxIntensity * fraction)}
+            />
+          ))}
+        </g>
+        <path d={pathD} stroke="url(#spectrum-gradient)" fill="none" strokeWidth={3} />
+        <path d={areaPath} fill="url(#fill-gradient)" opacity={0.2} />
+        <g className="axes">
+          <line
+            x1={padding.left}
+            x2={width - padding.right}
+            y1={height - padding.bottom}
+            y2={height - padding.bottom}
+          />
+          <line x1={padding.left} x2={padding.left} y1={padding.top} y2={height - padding.bottom} />
+        </g>
+        <g className="tick-labels">
+          {xTicks
+            .filter((tick) => tick >= minWavelength && tick <= maxWavelength)
+            .map((tick) => (
+              <text
+                key={tick}
+                x={toX(tick)}
+                y={height - padding.bottom + 24}
+                className="tick-label tick-label-x"
+                textAnchor="middle"
+              >
+                {tick}
+              </text>
+            ))}
+          {[0, 0.25, 0.5, 0.75, 1].map((fraction) => (
+            <text
+              key={fraction}
+              x={padding.left - 18}
+              y={toY(maxIntensity * fraction) + 4}
+              className="tick-label tick-label-y"
+              textAnchor="end"
+            >
+              {(maxIntensity * fraction).toFixed(2)}
+            </text>
+          ))}
+        </g>
+        <g className="peaks">
+          {peaks.map((peak) => (
+            <g key={peak.wavelength}>
+              <line
+                x1={toX(peak.wavelength)}
+                x2={toX(peak.wavelength)}
+                y1={toY(peak.intensity)}
+                y2={height - padding.bottom}
+                className="peak-marker"
+              />
+              <circle
+                cx={toX(peak.wavelength)}
+                cy={toY(peak.intensity)}
+                r={6}
+                className="peak-dot"
+              />
+              <text
+                x={toX(peak.wavelength)}
+                y={toY(peak.intensity) - 12}
+                className="peak-label"
+              >
+                {peak.wavelength} nm
+              </text>
+            </g>
+          ))}
+        </g>
+        <text
+          x={(padding.left + width - padding.right) / 2}
+          y={height - 4}
+          className="axis-label"
+          textAnchor="middle"
+        >
+          Wavelength (nm)
+        </text>
+        <text
+          className="axis-label"
+          textAnchor="middle"
+          transform={`translate(18 ${(padding.top + height - padding.bottom) / 2}) rotate(-90)`}
+        >
+          Intensity (a.u.)
+        </text>
+      </svg>
+    </figure>
+  )
+}
+
+function formatRange(spectrum) {
+  const minWavelength = Math.min(...spectrum.map((point) => point.wavelength))
+  const maxWavelength = Math.max(...spectrum.map((point) => point.wavelength))
+  return `${minWavelength}-${maxWavelength} nm`
+}
+
+function dominantPeak(sample) {
+  return sample.peaks.reduce((highest, peak) => {
+    if (!highest || peak.intensity > highest.intensity) {
+      return peak
+    }
+    return highest
+  }, null)
+}
+
+function App() {
+  const [selectedSampleId, setSelectedSampleId] = useState(SPECTRA[0].id)
+
+  const selectedSample = useMemo(
+    () => SPECTRA.find((sample) => sample.id === selectedSampleId) ?? SPECTRA[0],
+    [selectedSampleId]
+  )
+
+  return (
+    <div className="dashboard">
+      <header className="header">
+        <div>
+          <p className="badge">Spectroscopy Lab Notebook</p>
+          <h1>Spectral Results Overview</h1>
+          <p className="lede">
+            Explore recent absorbance scans captured across our pigment and protein studies. Select a
+            sample to review its spectral fingerprints, annotated peaks, and acquisition metadata.
+          </p>
+        </div>
+        <div className="selector">
+          <label htmlFor="sample-selector">Sample</label>
+          <select
+            id="sample-selector"
+            value={selectedSampleId}
+            onChange={(event) => setSelectedSampleId(event.target.value)}
+          >
+            {SPECTRA.map((sample) => (
+              <option key={sample.id} value={sample.id}>
+                {sample.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <main className="content">
+        <section className="panel panel-chart">
+          <div className="panel-header">
+            <h2>{selectedSample.name}</h2>
+            <div className="metadata">
+              <span>{selectedSample.project}</span>
+              <span>Collected {selectedSample.collectedOn}</span>
+              <span>{selectedSample.instrument}</span>
+            </div>
+          </div>
+          <p className="panel-summary">{selectedSample.summary}</p>
+          <SpectralChart
+            spectrum={selectedSample.spectrum}
+            peaks={selectedSample.peaks}
+            title={`${selectedSample.name} absorbance spectrum`}
+          />
+        </section>
+
+        <section className="panel panel-details">
+          <h3>Acquisition Details</h3>
+          <dl className="details-grid">
+            <div>
+              <dt>Solvent</dt>
+              <dd>{selectedSample.solvent}</dd>
+            </div>
+            <div>
+              <dt>Temperature</dt>
+              <dd>{selectedSample.temperature}</dd>
+            </div>
+            <div>
+              <dt>Normalization</dt>
+              <dd>{selectedSample.normalization}</dd>
+            </div>
+            <div>
+              <dt>Quality Check</dt>
+              <dd className={`quality quality-${selectedSample.quality.toLowerCase().replace(/\s+/g, '-')}`}>
+                {selectedSample.quality}
+              </dd>
+            </div>
+          </dl>
+
+          <div className="peak-highlights">
+            <h4>Annotated Peaks</h4>
+            <ul>
+              {selectedSample.peaks.map((peak) => (
+                <li key={peak.wavelength}>
+                  <span className="peak-wavelength">{peak.wavelength} nm</span>
+                  <span className="peak-intensity">{peak.intensity.toFixed(2)} a.u.</span>
+                  <p>{peak.assignment}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="panel panel-table">
+          <h3>Sample Comparison</h3>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Sample</th>
+                <th scope="col">λ Range</th>
+                <th scope="col">Dominant Peak</th>
+                <th scope="col">Peak Intensity</th>
+                <th scope="col">Quality</th>
+              </tr>
+            </thead>
+            <tbody>
+              {SPECTRA.map((sample) => {
+                const peak = dominantPeak(sample)
+                return (
+                  <tr key={sample.id} className={sample.id === selectedSample.id ? 'active' : ''}>
+                    <th scope="row">{sample.name}</th>
+                    <td>{formatRange(sample.spectrum)}</td>
+                    <td>{peak ? `${peak.wavelength} nm` : '—'}</td>
+                    <td>{peak ? peak.intensity.toFixed(2) : '—'} a.u.</td>
+                    <td>{sample.quality}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </section>
+      </main>
+    </div>
   )
 }
 

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,68 +1,35 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #e2e8f0;
+  background-color: #020617;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.25), transparent 45%),
+    radial-gradient(circle at 20% 80%, rgba(236, 72, 153, 0.15), transparent 55%),
+    radial-gradient(circle at right, rgba(45, 212, 191, 0.2), transparent 40%),
+    #020617;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
+select,
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- replace the starter counter view with a spectroscopy dashboard and curated datasets
- add an SVG-based spectral chart with interactive annotations and comparison table styling
- refresh global and component styling to support the laboratory-themed presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6663f20148320b110e82305d9dae3