### PR TITLE
feat: add rgb spectrum visualizer for wavelength datasets

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -237,7 +237,7 @@ body {
   color: #f8fafc;
 }
 
-.peaks-list__reflectance {
+.peaks-list__intensity {
   font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
   font-size: 0.9rem;

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,440 +1,257 @@
-#root {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 3rem 2.5rem 4rem;
-}
-
-.dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top, #1e293b, #0f172a 65%);
   color: #e2e8f0;
 }
 
-.header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 1.5rem;
-  align-items: flex-end;
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: transparent;
 }
 
-.header h1 {
-  margin: 0.25rem 0 0.75rem;
-  font-size: 2.4rem;
+#root {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3rem 1.75rem 4rem;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.app__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.app__header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 700;
   color: #f8fafc;
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border-radius: 999px;
-  background: rgba(56, 189, 248, 0.14);
-  color: #38bdf8;
+.app__header p {
   margin: 0;
+  max-width: 720px;
+  color: rgba(203, 213, 225, 0.9);
+  line-height: 1.7;
 }
 
-.lede {
-  margin: 0;
-  max-width: 620px;
-  color: #cbd5f5;
-  line-height: 1.6;
-}
-
-.selector {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  min-width: 220px;
-}
-
-.selector label {
-  font-weight: 600;
-  color: #e2e8f0;
-}
-
-.selector select {
-  padding: 0.65rem 0.85rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.6);
-  color: #f8fafc;
-  font-size: 1rem;
-  backdrop-filter: blur(6px);
-}
-
-.selector select:focus {
-  outline: 2px solid #38bdf8;
-  border-color: #38bdf8;
-}
-
-.content {
+.visualiser {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.75rem;
-}
-
-.panel {
+  gap: 2rem;
+  padding: 2.25rem;
+  border-radius: 1.5rem;
   background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
   border: 1px solid rgba(99, 102, 241, 0.18);
-  border-radius: 1.25rem;
-  padding: 1.75rem;
-  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(12px);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
 }
 
-.panel-description {
-  margin: 0;
-  color: #94a3b8;
-  font-size: 0.9rem;
-  max-width: 360px;
+.visualiser__inputs,
+.visualiser__chart,
+.visualiser__peaks {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.panel h2,
-.panel h3 {
+.inputs__header h2,
+.visualiser__chart h2,
+.visualiser__peaks h2 {
   margin: 0;
+  font-size: 1.4rem;
   color: #f1f5f9;
 }
 
-.panel-chart {
-  grid-column: 1 / -1;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.panel-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.75rem;
-  align-items: baseline;
-}
-
-.panel-header h2 {
-  font-size: 1.6rem;
-}
-
-.metadata {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  font-size: 0.9rem;
-  color: #cbd5f5;
-}
-
-.metadata span {
-  padding: 0.3rem 0.6rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.7);
-}
-
-.panel-summary {
+.inputs__header p {
   margin: 0;
-  color: #cbd5f5;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
   line-height: 1.6;
 }
 
-.spectral-chart {
+.dataset-input {
   width: 100%;
-  overflow: hidden;
   border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(59, 130, 246, 0.12);
-  padding: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  padding: 1rem 1.15rem;
+  resize: vertical;
+  min-height: 200px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }
 
-.spectral-chart svg {
+.dataset-input:focus {
+  outline: 2px solid #38bdf8;
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.2);
+}
+
+.input-hint {
+  margin: -0.35rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.input-warnings {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+  color: #facc15;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.spectrum-preview {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 110px;
+  box-shadow: inset 0 0 35px rgba(15, 23, 42, 0.45);
+  transition: background-image 0.3s ease, background-color 0.3s ease;
+}
+
+.chart {
+  position: relative;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  padding: 0.75rem;
+}
+
+.chart svg {
+  display: block;
   width: 100%;
   height: auto;
-  display: block;
 }
 
-.chart-surface {
+.chart__surface {
   fill: rgba(148, 163, 184, 0.05);
   stroke: rgba(148, 163, 184, 0.12);
   stroke-width: 1;
+  rx: 14px;
+  ry: 14px;
 }
 
-.grid line {
-  stroke: rgba(148, 163, 184, 0.12);
-  stroke-dasharray: 4 6;
+.chart__grid line {
+  stroke: rgba(148, 163, 184, 0.14);
+  stroke-dasharray: 4 8;
   shape-rendering: crispEdges;
 }
 
-.axes line {
-  stroke: rgba(148, 163, 184, 0.3);
-  stroke-width: 1.4;
+.chart__axes line {
+  stroke: rgba(148, 163, 184, 0.4);
+  stroke-width: 1.6;
 }
 
-.tick-label {
+.chart__tick {
   fill: #cbd5f5;
-  font-size: 0.7rem;
+  font-size: 0.75rem;
 }
 
-.tick-label-x {
+.chart__tick--x {
   text-anchor: middle;
 }
 
-.tick-label-y {
+.chart__tick--y {
   text-anchor: end;
 }
 
-.axis-label {
-  fill: #e2e8f0;
-  font-size: 0.8rem;
+.chart__axis-label {
+  fill: #f1f5f9;
   font-weight: 600;
+  font-size: 0.85rem;
   text-anchor: middle;
 }
 
-.peaks .peak-marker {
-  stroke: rgba(248, 113, 113, 0.55);
-  stroke-dasharray: 3 6;
-}
-
-.peaks .peak-dot {
-  fill: #f472b6;
-  stroke: rgba(248, 113, 113, 0.8);
+.chart__points circle {
+  fill: rgba(56, 189, 248, 0.85);
+  stroke: rgba(15, 23, 42, 0.9);
   stroke-width: 2;
 }
 
-.peaks .peak-label {
+.chart__peaks line {
+  stroke: rgba(248, 113, 113, 0.6);
+  stroke-dasharray: 3 6;
+}
+
+.chart__peaks circle {
+  fill: rgba(244, 114, 182, 0.9);
+  stroke: rgba(15, 23, 42, 0.9);
+  stroke-width: 2;
+}
+
+.chart__peaks text {
   fill: #fda4af;
-  font-size: 0.65rem;
+  font-size: 0.7rem;
   text-anchor: middle;
   font-weight: 600;
 }
 
-.panel-details {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.details-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.25rem;
+.chart__empty {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
   margin: 0;
-}
-
-.details-grid div {
-  background: rgba(15, 23, 42, 0.55);
+  padding: 0.75rem 1.2rem;
   border-radius: 0.85rem;
-  padding: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
 }
 
-.details-grid dt {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: rgba(148, 163, 184, 0.8);
-  margin-bottom: 0.35rem;
-}
-
-.details-grid dd {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #e2e8f0;
-}
-
-.quality {
-  font-weight: 600;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.quality-high {
-  background: rgba(52, 211, 153, 0.18);
-  color: #34d399;
-}
-
-.quality-research-grade {
-  background: rgba(129, 140, 248, 0.2);
-  color: #818cf8;
-}
-
-.quality-pass {
-  background: rgba(250, 204, 21, 0.18);
-  color: #facc15;
-}
-
-.peak-highlights h4 {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
-}
-
-.peak-highlights ul {
+.peaks-list {
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
 }
 
-.peak-highlights li {
-  padding: 0.9rem 1rem;
-  border-radius: 0.9rem;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-}
-
-.peak-wavelength {
-  font-weight: 600;
-  color: #f8fafc;
-  margin-right: 0.5rem;
-}
-
-.peak-intensity {
-  font-size: 0.85rem;
-  color: #94a3b8;
-}
-
-.peak-highlights p {
-  margin: 0.35rem 0 0;
-  color: #cbd5f5;
-  line-height: 1.4;
-}
-
-.panel-table table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
-  color: #e2e8f0;
-}
-
-.panel-table th,
-.panel-table td {
-  padding: 0.85rem;
-  text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
-}
-
-.panel-table tbody tr:last-of-type td {
-  border-bottom: none;
-}
-
-.panel-table tbody tr.active {
-  background: rgba(59, 130, 246, 0.15);
-}
-
-.panel-table tbody tr:hover {
-  background: rgba(148, 163, 184, 0.1);
-}
-
-.panel-rgb {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.rgb-input-label {
-  font-weight: 600;
-  color: #e2e8f0;
-}
-
-.rgb-input {
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.55);
-  color: #f8fafc;
+.peaks-list li {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: baseline;
+  gap: 0.6rem;
   padding: 0.85rem 1rem;
-  resize: vertical;
-  min-height: 3.5rem;
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.9rem;
-}
-
-.rgb-input:focus {
-  outline: 2px solid #38bdf8;
-  border-color: #38bdf8;
-}
-
-.input-hint {
-  margin: -0.25rem 0 0;
-  font-size: 0.75rem;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.input-warning {
-  margin: 0;
-  font-size: 0.75rem;
-  color: #facc15;
-}
-
-.spectrum-preview {
-  border-radius: 0.9rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  min-height: 80px;
+  border-radius: 1rem;
   background: rgba(15, 23, 42, 0.55);
-  box-shadow: inset 0 0 25px rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-.rgb-swatches {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.rgb-swatch {
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.55);
-  min-width: 180px;
-}
-
-.rgb-swatch.empty {
-  justify-content: center;
-  color: rgba(148, 163, 184, 0.75);
-  font-style: italic;
-}
-
-.swatch-chip {
-  width: 40px;
-  height: 40px;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.45);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.4);
-}
-
-.swatch-wavelength {
-  margin: 0;
-  color: #f8fafc;
+.peaks-list__wavelength {
   font-weight: 600;
+  color: #f8fafc;
 }
 
-.swatch-rgb {
-  margin: 0.2rem 0 0;
+.peaks-list__reflectance {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  font-size: 0.9rem;
   color: #cbd5f5;
-  font-size: 0.8rem;
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
 }
 
-.swatch-alpha {
-  margin: 0.2rem 0 0;
-  color: rgba(148, 163, 184, 0.8);
+.peaks-list__label {
   font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.peaks-empty {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .sr-only {
@@ -449,16 +266,37 @@
   border: 0;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 960px) {
+  .visualiser {
+    grid-template-columns: minmax(260px, 340px) 1fr;
+    grid-template-areas:
+      'inputs chart'
+      'peaks chart';
+  }
+
+  .visualiser__inputs {
+    grid-area: inputs;
+  }
+
+  .visualiser__chart {
+    grid-area: chart;
+  }
+
+  .visualiser__peaks {
+    grid-area: peaks;
+  }
+}
+
+@media (max-width: 640px) {
   #root {
-    padding: 2.5rem 1.5rem 3rem;
+    padding: 2.5rem 1.25rem 3.25rem;
   }
 
-  .header {
-    align-items: flex-start;
+  .visualiser {
+    padding: 1.75rem;
   }
 
-  .panel {
-    padding: 1.5rem;
+  .dataset-input {
+    min-height: 180px;
   }
 }

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -89,6 +89,13 @@
   backdrop-filter: blur(12px);
 }
 
+.panel-description {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  max-width: 360px;
+}
+
 .panel h2,
 .panel h3 {
   margin: 0;
@@ -325,6 +332,109 @@
 
 .panel-table tbody tr:hover {
   background: rgba(148, 163, 184, 0.1);
+}
+
+.panel-rgb {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rgb-input-label {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.rgb-input {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  padding: 0.85rem 1rem;
+  resize: vertical;
+  min-height: 3.5rem;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+}
+
+.rgb-input:focus {
+  outline: 2px solid #38bdf8;
+  border-color: #38bdf8;
+}
+
+.input-hint {
+  margin: -0.25rem 0 0;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.input-warning {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #facc15;
+}
+
+.spectrum-preview {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  min-height: 80px;
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 25px rgba(15, 23, 42, 0.45);
+}
+
+.rgb-swatches {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.rgb-swatch {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.55);
+  min-width: 180px;
+}
+
+.rgb-swatch.empty {
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+.swatch-chip {
+  width: 40px;
+  height: 40px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.45);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.4);
+}
+
+.swatch-wavelength {
+  margin: 0;
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.swatch-rgb {
+  margin: 0.2rem 0 0;
+  color: #cbd5f5;
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+}
+
+.swatch-alpha {
+  margin: 0.2rem 0 0;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.75rem;
 }
 
 .sr-only {

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -21,7 +21,7 @@ function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max)
 }
 
-function wavelengthToRGB(wavelength, reflectance = 1) {
+function wavelengthToRGB(wavelength, intensity = 1) {
   if (Number.isNaN(wavelength) || wavelength < VISIBLE_RANGE.min || wavelength > VISIBLE_RANGE.max) {
     return { r: 0, g: 0, b: 0, alpha: 0 }
   }
@@ -56,8 +56,7 @@ function wavelengthToRGB(wavelength, reflectance = 1) {
     visibilityFactor = 0.3 + (0.7 * (VISIBLE_RANGE.max - wavelength)) / (VISIBLE_RANGE.max - 700)
   }
 
-  const reflectanceFactor = clamp(reflectance, 0, 1)
-  const intensityFactor = visibilityFactor * reflectanceFactor
+  const intensityFactor = visibilityFactor * clamp(intensity, 0, 1)
   const normalise = (value) => Math.round(255 * value * intensityFactor)
 
   return {
@@ -91,22 +90,22 @@ function parseDataset(input) {
       .filter((value) => !Number.isNaN(value))
 
     if (numbers.length < 2) {
-      warnings.push(`Line ${lineIndex + 1}: enter both wavelength and reflectance values.`)
+      warnings.push(`Line ${lineIndex + 1}: enter both wavelength and intensity values.`)
       return
     }
 
-    const [wavelength, reflectance] = numbers
+    const [wavelength, intensity] = numbers
     if (wavelength < VISIBLE_RANGE.min || wavelength > VISIBLE_RANGE.max) {
       warnings.push(`Line ${lineIndex + 1}: ${wavelength.toFixed(1)} nm is outside the visible range.`)
       return
     }
 
-    if (reflectance < 0 || reflectance > 1) {
-      warnings.push(`Line ${lineIndex + 1}: reflectance ${reflectance.toFixed(2)} must be between 0 and 1.`)
+    if (intensity < 0 || intensity > 1) {
+      warnings.push(`Line ${lineIndex + 1}: intensity ${intensity.toFixed(2)} must be between 0 and 1.`)
       return
     }
 
-    points.push({ wavelength, reflectance })
+    points.push({ wavelength, intensity })
   })
 
   points.sort((a, b) => a.wavelength - b.wavelength)
@@ -125,11 +124,11 @@ function detectPeaks(points) {
     const prev = points[index - 1]
     const next = points[index + 1]
 
-    const isLeftHigher = !prev || current.reflectance >= prev.reflectance
-    const isRightHigher = !next || current.reflectance >= next.reflectance
+    const isLeftHigher = !prev || current.intensity >= prev.intensity
+    const isRightHigher = !next || current.intensity >= next.intensity
     const isStrictPeak =
-      (prev && current.reflectance > prev.reflectance) ||
-      (next && current.reflectance > next.reflectance)
+      (prev && current.intensity > prev.intensity) ||
+      (next && current.intensity > next.intensity)
 
     if (isLeftHigher && isRightHigher && (prev || next)) {
       if (!prev || !next || isStrictPeak) {
@@ -138,14 +137,14 @@ function detectPeaks(points) {
     }
   }
 
-  return peaks.sort((a, b) => b.reflectance - a.reflectance)
+  return peaks.sort((a, b) => b.intensity - a.intensity)
 }
 
-function formatReflectance(value) {
+function formatIntensity(value) {
   return value >= 0.995 ? '1.00' : value.toFixed(2)
 }
 
-function ReflectanceChart({ points, peaks }) {
+function IntensityChart({ points, peaks }) {
   const width = 720
   const height = 360
   const padding = { top: 36, right: 32, bottom: 56, left: 72 }
@@ -153,18 +152,17 @@ function ReflectanceChart({ points, peaks }) {
   const chartWidth = width - padding.left - padding.right
   const chartHeight = height - padding.top - padding.bottom
 
-  const maxReflectance = points.length > 0 ? Math.max(1, ...points.map((point) => point.reflectance)) : 1
+  const maxIntensity = points.length > 0 ? Math.max(1, ...points.map((point) => point.intensity)) : 1
 
   const toX = (wavelength) =>
     padding.left + ((wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * chartWidth
 
-  const toY = (reflectance) =>
-    padding.top + chartHeight - (reflectance / maxReflectance) * chartHeight
+  const toY = (intensity) => padding.top + chartHeight - (intensity / maxIntensity) * chartHeight
 
   const pathD = points
     .map((point, index) => {
       const command = index === 0 ? 'M' : 'L'
-      return `${command}${toX(point.wavelength)},${toY(point.reflectance)}`
+      return `${command}${toX(point.wavelength)},${toY(point.intensity)}`
     })
     .join(' ')
 
@@ -176,18 +174,18 @@ function ReflectanceChart({ points, peaks }) {
 
   const yTickCount = 4
   const yTicks = Array.from({ length: yTickCount + 1 }, (_, tickIndex) =>
-    Number.parseFloat(((maxReflectance / yTickCount) * tickIndex).toFixed(2))
+    Number.parseFloat(((maxIntensity / yTickCount) * tickIndex).toFixed(2))
   )
 
   return (
     <figure className="chart" aria-labelledby="chart-title">
       <figcaption id="chart-title" className="sr-only">
-        Reflectance spectrum plotted against wavelength in nanometres
+        Intensity spectrum plotted against wavelength in nanometres
       </figcaption>
       <svg
         viewBox={`0 0 ${width} ${height}`}
         role="img"
-        aria-label="Reflectance versus wavelength"
+        aria-label="Intensity versus wavelength"
         preserveAspectRatio="xMidYMid meet"
       >
         <defs>
@@ -232,9 +230,9 @@ function ReflectanceChart({ points, peaks }) {
             <g className="chart__points">
               {points.map((point) => (
                 <circle
-                  key={`${point.wavelength}-${point.reflectance}`}
+                  key={`${point.wavelength}-${point.intensity}`}
                   cx={toX(point.wavelength)}
-                  cy={toY(point.reflectance)}
+                  cy={toY(point.intensity)}
                   r={4}
                   className="chart__point"
                 />
@@ -242,15 +240,15 @@ function ReflectanceChart({ points, peaks }) {
             </g>
             <g className="chart__peaks">
               {peaks.map((peak) => (
-                <g key={`peak-${peak.wavelength}-${peak.reflectance}`} className="chart__peak">
+                <g key={`peak-${peak.wavelength}-${peak.intensity}`} className="chart__peak">
                   <line
                     x1={toX(peak.wavelength)}
                     x2={toX(peak.wavelength)}
-                    y1={toY(peak.reflectance)}
+                    y1={toY(peak.intensity)}
                     y2={padding.top + chartHeight}
                   />
-                  <circle cx={toX(peak.wavelength)} cy={toY(peak.reflectance)} r={7} />
-                  <text x={toX(peak.wavelength)} y={toY(peak.reflectance) - 14}>
+                  <circle cx={toX(peak.wavelength)} cy={toY(peak.intensity)} r={7} />
+                  <text x={toX(peak.wavelength)} y={toY(peak.intensity) - 14}>
                     {`${peak.wavelength.toFixed(0)} nm`}
                   </text>
                 </g>
@@ -282,14 +280,14 @@ function ReflectanceChart({ points, peaks }) {
             className="chart__axis-label"
             transform={`translate(${24} ${padding.top + chartHeight / 2}) rotate(-90)`}
           >
-            Reflectance
+            Intensity
           </text>
         </g>
       </svg>
 
       {points.length === 0 && (
         <p className="chart__empty" role="status">
-          Add wavelength and reflectance values to plot the spectrum.
+          Add wavelength and intensity values to plot the spectrum.
         </p>
       )}
     </figure>
@@ -312,7 +310,7 @@ function App() {
 
     const gradientStops = points
       .map((point) => {
-        const color = wavelengthToRGB(point.wavelength, point.reflectance)
+        const color = wavelengthToRGB(point.wavelength, point.intensity)
         const position = ((point.wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * 100
         return `${formatRGB(color)} ${position.toFixed(1)}%`
       })
@@ -327,10 +325,10 @@ function App() {
   return (
     <div className="app">
       <header className="app__header">
-        <h1>RGB Reflectance Spectrum Visualiser</h1>
+        <h1>RGB Spectrum Intensity Visualiser</h1>
         <p>
-          Enter a dataset of reflected wavelengths and their relative reflectance values to explore how the spectrum shifts
-          across the visible range. Peaks highlight where an object reflects the most light.
+          Enter a dataset of wavelengths and relative intensity values to explore how the spectrum shifts across the
+          visible range. Peaks highlight where an object emits or reflects the most light.
         </p>
       </header>
 
@@ -338,7 +336,7 @@ function App() {
         <section className="visualiser__inputs" aria-labelledby="dataset-label">
           <div className="inputs__header">
             <h2 id="dataset-label">Wavelength dataset</h2>
-            <p>Provide wavelength (nm) and reflectance pairs. One pair per line, separated by spaces or commas.</p>
+            <p>Provide wavelength (nm) and intensity pairs. One pair per line, separated by spaces or commas.</p>
           </div>
           <textarea
             className="dataset-input"
@@ -349,7 +347,7 @@ function App() {
             aria-describedby="dataset-hint"
           />
           <p id="dataset-hint" className="input-hint">
-            Visible wavelengths run from 380&nbsp;nm to 780&nbsp;nm. Reflectance values should be between 0 and 1.
+            Visible wavelengths run from 380&nbsp;nm to 780&nbsp;nm. Intensity values should be between 0 and 1.
           </p>
           {warnings.length > 0 && (
             <ul className="input-warnings" role="status">
@@ -358,23 +356,23 @@ function App() {
               ))}
             </ul>
           )}
-          <div className="spectrum-preview" style={previewStyle} role="img" aria-label="RGB preview of the reflected spectrum" />
+          <div className="spectrum-preview" style={previewStyle} role="img" aria-label="RGB preview of the intensity spectrum" />
         </section>
 
         <section className="visualiser__chart">
-          <h2>Reflectance spectrum</h2>
-          <ReflectanceChart points={points} peaks={peaks} />
+          <h2>Intensity spectrum</h2>
+          <IntensityChart points={points} peaks={peaks} />
         </section>
 
         <section className="visualiser__peaks">
-          <h2>Detected reflectance peaks</h2>
+          <h2>Detected intensity peaks</h2>
           {peaks.length > 0 ? (
             <ul className="peaks-list">
               {peaks.map((peak) => (
-                <li key={`peak-list-${peak.wavelength}-${peak.reflectance}`}>
+                <li key={`peak-list-${peak.wavelength}-${peak.intensity}`}>
                   <span className="peaks-list__wavelength">{peak.wavelength.toFixed(0)} nm</span>
-                  <span className="peaks-list__reflectance">{formatReflectance(peak.reflectance)}</span>
-                  <span className="peaks-list__label">relative reflectance</span>
+                  <span className="peaks-list__intensity">{formatIntensity(peak.intensity)}</span>
+                  <span className="peaks-list__label">relative intensity</span>
                 </li>
               ))}
             </ul>

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,109 +1,27 @@
-import { useId, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import './App.css'
 
-const SPECTRA = [
-  {
-    id: 'chlorophyll-extract',
-    name: 'Chlorophyll Extract',
-    project: 'Leaf Pigment Stability Week 4',
-    collectedOn: '2024-04-18',
-    solvent: '90% acetone',
-    temperature: '22 °C',
-    instrument: 'Shimadzu UV-2600 UV-Vis',
-    normalization: 'Absorbance normalized to 1 cm cuvette path length',
-    summary:
-      'Strong Soret band near 430 nm with a secondary Q-band at 662 nm indicating intact chlorophyll a with minor pheophytinization.',
-    spectrum: [
-      { wavelength: 390, intensity: 0.18 },
-      { wavelength: 410, intensity: 0.36 },
-      { wavelength: 430, intensity: 0.92 },
-      { wavelength: 450, intensity: 0.58 },
-      { wavelength: 470, intensity: 0.36 },
-      { wavelength: 500, intensity: 0.42 },
-      { wavelength: 550, intensity: 0.30 },
-      { wavelength: 600, intensity: 0.54 },
-      { wavelength: 630, intensity: 0.74 },
-      { wavelength: 650, intensity: 0.82 },
-      { wavelength: 662, intensity: 0.87 },
-      { wavelength: 680, intensity: 0.78 },
-      { wavelength: 700, intensity: 0.46 },
-    ],
-    peaks: [
-      { wavelength: 430, intensity: 0.92, assignment: 'Soret transition (π→π*)' },
-      { wavelength: 662, intensity: 0.87, assignment: 'Qy transition, chlorophyll a' },
-    ],
-    quality: 'High',
-  },
-  {
-    id: 'anthocyanin',
-    name: 'Anthocyanin Fraction',
-    project: 'Berry Pigment Profiling',
-    collectedOn: '2024-04-22',
-    solvent: 'Methanol + 0.1% HCl',
-    temperature: '20 °C',
-    instrument: 'Thermo Scientific Evolution 350',
-    normalization: 'Baseline corrected to blank solvent at 540 nm',
-    summary:
-      'Dominant λmax at 526 nm consistent with cyanidin-based anthocyanins. Subtle shoulder in the blue region indicates co-pigmentation.',
-    spectrum: [
-      { wavelength: 380, intensity: 0.12 },
-      { wavelength: 400, intensity: 0.21 },
-      { wavelength: 430, intensity: 0.35 },
-      { wavelength: 460, intensity: 0.48 },
-      { wavelength: 490, intensity: 0.64 },
-      { wavelength: 510, intensity: 0.82 },
-      { wavelength: 526, intensity: 0.95 },
-      { wavelength: 540, intensity: 0.88 },
-      { wavelength: 560, intensity: 0.74 },
-      { wavelength: 600, intensity: 0.46 },
-      { wavelength: 640, intensity: 0.28 },
-      { wavelength: 680, intensity: 0.16 },
-    ],
-    peaks: [
-      { wavelength: 526, intensity: 0.95, assignment: 'π→π* transition, cyanidin derivatives' },
-      { wavelength: 460, intensity: 0.48, assignment: 'Blue co-pigmentation shoulder' },
-    ],
-    quality: 'Research grade',
-  },
-  {
-    id: 'protein-aromatic',
-    name: 'Protein Aromatic Residues',
-    project: 'Protein Folding Monitoring',
-    collectedOn: '2024-04-26',
-    solvent: 'Phosphate buffer pH 7.4',
-    temperature: '25 °C',
-    instrument: 'Jasco J-815 CD with absorption detector',
-    normalization: 'Absorbance scaled to molar extinction at 280 nm',
-    summary:
-      'Tryptophan band centered near 280 nm with phenylalanine shoulder around 258 nm. No scattering artifacts observed.',
-    spectrum: [
-      { wavelength: 240, intensity: 0.20 },
-      { wavelength: 250, intensity: 0.32 },
-      { wavelength: 258, intensity: 0.44 },
-      { wavelength: 265, intensity: 0.52 },
-      { wavelength: 275, intensity: 0.68 },
-      { wavelength: 280, intensity: 0.94 },
-      { wavelength: 290, intensity: 0.88 },
-      { wavelength: 300, intensity: 0.64 },
-      { wavelength: 310, intensity: 0.42 },
-      { wavelength: 320, intensity: 0.30 },
-    ],
-    peaks: [
-      { wavelength: 280, intensity: 0.94, assignment: 'Tryptophan π→π*' },
-      { wavelength: 258, intensity: 0.44, assignment: 'Phenylalanine ring transition' },
-    ],
-    quality: 'Pass',
-  },
-]
-
-const xTicks = [
-  240, 260, 280, 300, 320, 340, 360, 380, 400, 420, 440, 460, 480, 500, 520, 540, 560, 580, 600,
-  620, 640, 660, 680, 700
-]
-
 const VISIBLE_RANGE = { min: 380, max: 780 }
+const X_TICKS = [380, 420, 460, 500, 540, 580, 620, 660, 700, 740, 780]
+const DEFAULT_DATASET = `410 0.08
+430 0.12
+450 0.2
+470 0.42
+490 0.58
+510 0.76
+530 0.92
+550 0.78
+570 0.54
+590 0.32
+610 0.22
+630 0.18
+650 0.16`
 
-function wavelengthToRGB(wavelength) {
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function wavelengthToRGB(wavelength, reflectance = 1) {
   if (Number.isNaN(wavelength) || wavelength < VISIBLE_RANGE.min || wavelength > VISIBLE_RANGE.max) {
     return { r: 0, g: 0, b: 0, alpha: 0 }
   }
@@ -131,13 +49,15 @@ function wavelengthToRGB(wavelength) {
     red = 1
   }
 
-  let intensityFactor = 1
+  let visibilityFactor = 1
   if (wavelength < 420) {
-    intensityFactor = 0.3 + (0.7 * (wavelength - 380)) / (420 - 380)
+    visibilityFactor = 0.3 + (0.7 * (wavelength - 380)) / (420 - 380)
   } else if (wavelength > 700) {
-    intensityFactor = 0.3 + (0.7 * (VISIBLE_RANGE.max - wavelength)) / (VISIBLE_RANGE.max - 700)
+    visibilityFactor = 0.3 + (0.7 * (VISIBLE_RANGE.max - wavelength)) / (VISIBLE_RANGE.max - 700)
   }
 
+  const reflectanceFactor = clamp(reflectance, 0, 1)
+  const intensityFactor = visibilityFactor * reflectanceFactor
   const normalise = (value) => Math.round(255 * value * intensityFactor)
 
   return {
@@ -155,429 +75,313 @@ function formatRGB({ r, g, b, alpha }) {
   return `rgb(${r}, ${g}, ${b})`
 }
 
-function SpectralChart({ spectrum, peaks, title }) {
-  const width = 640
-  const height = 280
-  const padding = { top: 20, right: 20, bottom: 40, left: 48 }
-  const titleId = useId()
+function parseDataset(input) {
+  const points = []
+  const warnings = []
 
-  const minWavelength = Math.min(...spectrum.map((point) => point.wavelength))
-  const maxWavelength = Math.max(...spectrum.map((point) => point.wavelength))
-  const maxIntensity = Math.max(...spectrum.map((point) => point.intensity))
+  input.split(/\n/).forEach((line, lineIndex) => {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      return
+    }
 
-  const toX = (wavelength) => {
-    return (
-      padding.left +
-      ((wavelength - minWavelength) / (maxWavelength - minWavelength)) *
-        (width - padding.left - padding.right)
-    )
+    const numbers = trimmed
+      .split(/[\s,]+/)
+      .map((token) => Number.parseFloat(token))
+      .filter((value) => !Number.isNaN(value))
+
+    if (numbers.length < 2) {
+      warnings.push(`Line ${lineIndex + 1}: enter both wavelength and reflectance values.`)
+      return
+    }
+
+    const [wavelength, reflectance] = numbers
+    if (wavelength < VISIBLE_RANGE.min || wavelength > VISIBLE_RANGE.max) {
+      warnings.push(`Line ${lineIndex + 1}: ${wavelength.toFixed(1)} nm is outside the visible range.`)
+      return
+    }
+
+    if (reflectance < 0 || reflectance > 1) {
+      warnings.push(`Line ${lineIndex + 1}: reflectance ${reflectance.toFixed(2)} must be between 0 and 1.`)
+      return
+    }
+
+    points.push({ wavelength, reflectance })
+  })
+
+  points.sort((a, b) => a.wavelength - b.wavelength)
+  return { points, warnings }
+}
+
+function detectPeaks(points) {
+  if (points.length < 2) {
+    return []
   }
 
-  const toY = (intensity) => {
-    return (
-      height -
-      padding.bottom -
-      (intensity / maxIntensity) * (height - padding.top - padding.bottom)
-    )
+  const peaks = []
+
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index]
+    const prev = points[index - 1]
+    const next = points[index + 1]
+
+    const isLeftHigher = !prev || current.reflectance >= prev.reflectance
+    const isRightHigher = !next || current.reflectance >= next.reflectance
+    const isStrictPeak =
+      (prev && current.reflectance > prev.reflectance) ||
+      (next && current.reflectance > next.reflectance)
+
+    if (isLeftHigher && isRightHigher && (prev || next)) {
+      if (!prev || !next || isStrictPeak) {
+        peaks.push({ ...current, index })
+      }
+    }
   }
 
-  const pathD = spectrum
+  return peaks.sort((a, b) => b.reflectance - a.reflectance)
+}
+
+function formatReflectance(value) {
+  return value >= 0.995 ? '1.00' : value.toFixed(2)
+}
+
+function ReflectanceChart({ points, peaks }) {
+  const width = 720
+  const height = 360
+  const padding = { top: 36, right: 32, bottom: 56, left: 72 }
+
+  const chartWidth = width - padding.left - padding.right
+  const chartHeight = height - padding.top - padding.bottom
+
+  const maxReflectance = points.length > 0 ? Math.max(1, ...points.map((point) => point.reflectance)) : 1
+
+  const toX = (wavelength) =>
+    padding.left + ((wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * chartWidth
+
+  const toY = (reflectance) =>
+    padding.top + chartHeight - (reflectance / maxReflectance) * chartHeight
+
+  const pathD = points
     .map((point, index) => {
-      const prefix = index === 0 ? 'M' : 'L'
-      return `${prefix}${toX(point.wavelength)},${toY(point.intensity)}`
+      const command = index === 0 ? 'M' : 'L'
+      return `${command}${toX(point.wavelength)},${toY(point.reflectance)}`
     })
     .join(' ')
 
-  const areaPath = `${pathD} L${toX(spectrum[spectrum.length - 1].wavelength)},${
-    height - padding.bottom
-  } L${toX(spectrum[0].wavelength)},${height - padding.bottom} Z`
+  const areaPath = points.length
+    ? `${pathD} L${toX(points[points.length - 1].wavelength)},${padding.top + chartHeight} L${toX(points[0].wavelength)},${
+        padding.top + chartHeight
+      } Z`
+    : ''
+
+  const yTickCount = 4
+  const yTicks = Array.from({ length: yTickCount + 1 }, (_, tickIndex) =>
+    Number.parseFloat(((maxReflectance / yTickCount) * tickIndex).toFixed(2))
+  )
 
   return (
-    <figure className="spectral-chart" aria-labelledby={titleId}>
-      <figcaption id={titleId} className="sr-only">
-        {title}
+    <figure className="chart" aria-labelledby="chart-title">
+      <figcaption id="chart-title" className="sr-only">
+        Reflectance spectrum plotted against wavelength in nanometres
       </figcaption>
       <svg
         viewBox={`0 0 ${width} ${height}`}
         role="img"
-        aria-label={`${title}. Peak intensity ${maxIntensity.toFixed(2)} absorbance units.`}
+        aria-label="Reflectance versus wavelength"
         preserveAspectRatio="xMidYMid meet"
       >
         <defs>
-          <linearGradient id="spectrum-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
+          <linearGradient id="line-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
             <stop offset="0%" stopColor="#38bdf8" />
             <stop offset="50%" stopColor="#a855f7" />
             <stop offset="100%" stopColor="#f472b6" />
           </linearGradient>
-          <linearGradient id="fill-gradient" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.6" />
+          <linearGradient id="area-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.35" />
             <stop offset="100%" stopColor="#0f172a" stopOpacity="0" />
           </linearGradient>
-          <radialGradient id="grid-bg">
-            <stop offset="0%" stopColor="#0f172a" stopOpacity="0.05" />
-            <stop offset="100%" stopColor="#0f172a" stopOpacity="0.3" />
-          </radialGradient>
         </defs>
+
         <rect
           x={padding.left}
           y={padding.top}
-          width={width - padding.left - padding.right}
-          height={height - padding.top - padding.bottom}
-          fill="url(#grid-bg)"
-          className="chart-surface"
+          width={chartWidth}
+          height={chartHeight}
+          className="chart__surface"
         />
-        <g className="grid">
-          {xTicks
-            .filter((tick) => tick > minWavelength && tick < maxWavelength)
-            .map((tick) => (
-              <line
-                key={tick}
-                x1={toX(tick)}
-                x2={toX(tick)}
-                y1={padding.top}
-                y2={height - padding.bottom}
-              />
-            ))}
-          {[0.25, 0.5, 0.75, 1].map((fraction) => (
+
+        <g className="chart__grid">
+          {X_TICKS.map((tick) => (
+            <line key={tick} x1={toX(tick)} x2={toX(tick)} y1={padding.top} y2={padding.top + chartHeight} />
+          ))}
+          {yTicks.map((tick) => (
             <line
-              key={fraction}
+              key={`y-${tick}`}
               x1={padding.left}
-              x2={width - padding.right}
-              y1={toY(maxIntensity * fraction)}
-              y2={toY(maxIntensity * fraction)}
+              x2={padding.left + chartWidth}
+              y1={toY(tick)}
+              y2={toY(tick)}
             />
           ))}
         </g>
-        <path d={pathD} stroke="url(#spectrum-gradient)" fill="none" strokeWidth={3} />
-        <path d={areaPath} fill="url(#fill-gradient)" opacity={0.2} />
-        <g className="axes">
-          <line
-            x1={padding.left}
-            x2={width - padding.right}
-            y1={height - padding.bottom}
-            y2={height - padding.bottom}
-          />
-          <line x1={padding.left} x2={padding.left} y1={padding.top} y2={height - padding.bottom} />
+
+        {points.length > 0 && (
+          <>
+            <path d={pathD} fill="none" stroke="url(#line-gradient)" strokeWidth={3} strokeLinejoin="round" />
+            <path d={areaPath} fill="url(#area-gradient)" />
+            <g className="chart__points">
+              {points.map((point) => (
+                <circle
+                  key={`${point.wavelength}-${point.reflectance}`}
+                  cx={toX(point.wavelength)}
+                  cy={toY(point.reflectance)}
+                  r={4}
+                  className="chart__point"
+                />
+              ))}
+            </g>
+            <g className="chart__peaks">
+              {peaks.map((peak) => (
+                <g key={`peak-${peak.wavelength}-${peak.reflectance}`} className="chart__peak">
+                  <line
+                    x1={toX(peak.wavelength)}
+                    x2={toX(peak.wavelength)}
+                    y1={toY(peak.reflectance)}
+                    y2={padding.top + chartHeight}
+                  />
+                  <circle cx={toX(peak.wavelength)} cy={toY(peak.reflectance)} r={7} />
+                  <text x={toX(peak.wavelength)} y={toY(peak.reflectance) - 14}>
+                    {`${peak.wavelength.toFixed(0)} nm`}
+                  </text>
+                </g>
+              ))}
+            </g>
+          </>
+        )}
+
+        <g className="chart__axes">
+          <line x1={padding.left} x2={padding.left + chartWidth} y1={padding.top + chartHeight} y2={padding.top + chartHeight} />
+          <line x1={padding.left} x2={padding.left} y1={padding.top} y2={padding.top + chartHeight} />
         </g>
-        <g className="tick-labels">
-          {xTicks
-            .filter((tick) => tick >= minWavelength && tick <= maxWavelength)
-            .map((tick) => (
-              <text
-                key={tick}
-                x={toX(tick)}
-                y={height - padding.bottom + 24}
-                className="tick-label tick-label-x"
-                textAnchor="middle"
-              >
-                {tick}
-              </text>
-            ))}
-          {[0, 0.25, 0.5, 0.75, 1].map((fraction) => (
-            <text
-              key={fraction}
-              x={padding.left - 18}
-              y={toY(maxIntensity * fraction) + 4}
-              className="tick-label tick-label-y"
-              textAnchor="end"
-            >
-              {(maxIntensity * fraction).toFixed(2)}
+
+        <g className="chart__labels">
+          {X_TICKS.map((tick) => (
+            <text key={`tick-x-${tick}`} x={toX(tick)} y={padding.top + chartHeight + 28} className="chart__tick chart__tick--x">
+              {tick}
             </text>
           ))}
-        </g>
-        <g className="peaks">
-          {peaks.map((peak) => (
-            <g key={peak.wavelength}>
-              <line
-                x1={toX(peak.wavelength)}
-                x2={toX(peak.wavelength)}
-                y1={toY(peak.intensity)}
-                y2={height - padding.bottom}
-                className="peak-marker"
-              />
-              <circle
-                cx={toX(peak.wavelength)}
-                cy={toY(peak.intensity)}
-                r={6}
-                className="peak-dot"
-              />
-              <text
-                x={toX(peak.wavelength)}
-                y={toY(peak.intensity) - 12}
-                className="peak-label"
-              >
-                {peak.wavelength} nm
-              </text>
-            </g>
+          {yTicks.map((tick) => (
+            <text key={`tick-y-${tick}`} x={padding.left - 16} y={toY(tick) + 4} className="chart__tick chart__tick--y">
+              {tick.toFixed(2)}
+            </text>
           ))}
+          <text x={padding.left + chartWidth / 2} y={height - 12} className="chart__axis-label">
+            Wavelength (nm)
+          </text>
+          <text
+            className="chart__axis-label"
+            transform={`translate(${24} ${padding.top + chartHeight / 2}) rotate(-90)`}
+          >
+            Reflectance
+          </text>
         </g>
-        <text
-          x={(padding.left + width - padding.right) / 2}
-          y={height - 4}
-          className="axis-label"
-          textAnchor="middle"
-        >
-          Wavelength (nm)
-        </text>
-        <text
-          className="axis-label"
-          textAnchor="middle"
-          transform={`translate(18 ${(padding.top + height - padding.bottom) / 2}) rotate(-90)`}
-        >
-          Intensity (a.u.)
-        </text>
       </svg>
+
+      {points.length === 0 && (
+        <p className="chart__empty" role="status">
+          Add wavelength and reflectance values to plot the spectrum.
+        </p>
+      )}
     </figure>
   )
 }
 
-function formatRange(spectrum) {
-  const minWavelength = Math.min(...spectrum.map((point) => point.wavelength))
-  const maxWavelength = Math.max(...spectrum.map((point) => point.wavelength))
-  return `${minWavelength}-${maxWavelength} nm`
-}
-
-function dominantPeak(sample) {
-  return sample.peaks.reduce((highest, peak) => {
-    if (!highest || peak.intensity > highest.intensity) {
-      return peak
-    }
-    return highest
-  }, null)
-}
-
-function RGBSpectrumVisualizer({ input, onChange }) {
-  const { wavelengths, invalidTokens } = useMemo(() => {
-    const tokens = input.split(/[^0-9.]+/)
-    const parsed = tokens
-      .map((token) => Number.parseFloat(token))
-      .filter((value) => !Number.isNaN(value))
-
-    const valid = parsed.filter(
-      (value) => value >= VISIBLE_RANGE.min && value <= VISIBLE_RANGE.max
-    )
-
-    const invalid = parsed.filter(
-      (value) => value < VISIBLE_RANGE.min || value > VISIBLE_RANGE.max
-    )
-
-    return { wavelengths: valid, invalidTokens: invalid }
-  }, [input])
-
-  const spectrum = useMemo(
-    () =>
-      wavelengths.map((wavelength) => ({
-        wavelength,
-        color: wavelengthToRGB(wavelength),
-      })),
-    [wavelengths]
-  )
-
-  const formatWavelength = (value) => (Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1))
-  const formatInvalid = formatWavelength
-
-  const gradientStops = [...spectrum]
-    .sort((a, b) => a.wavelength - b.wavelength)
-    .map(({ wavelength, color }) => {
-      const position = ((wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * 100
-      return `${formatRGB(color)} ${position.toFixed(1)}%`
-    })
-    .join(', ')
-
-  const gradientStyle = spectrum.length
-    ? { backgroundImage: `linear-gradient(90deg, ${gradientStops})` }
-    : { backgroundColor: 'rgba(15, 23, 42, 0.65)' }
-
-  return (
-    <section className="panel panel-rgb" aria-labelledby="rgb-visualizer-heading">
-      <div className="panel-header">
-        <h3 id="rgb-visualizer-heading">RGB Spectrum Visualizer</h3>
-        <p className="panel-description">
-          Enter wavelengths between 380 nm and 780 nm to approximate their contribution to the visible
-          RGB spectrum.
-        </p>
-      </div>
-
-      <label className="rgb-input-label" htmlFor="wavelength-dataset">
-        Wavelength dataset
-      </label>
-      <textarea
-        id="wavelength-dataset"
-        value={input}
-        onChange={(event) => onChange(event.target.value)}
-        className="rgb-input"
-        placeholder="e.g. 450, 495, 570, 615, 680"
-        rows={3}
-      />
-      <p className="input-hint">
-        Separate values with commas, spaces, or line breaks. Values outside the visible range are ignored.
-      </p>
-      {invalidTokens.length > 0 && (
-        <p className="input-warning" role="status">
-          Ignored {invalidTokens.length} value{invalidTokens.length > 1 ? 's' : ''} outside the visible
-          range{invalidTokens.length <= 5
-            ? `: ${invalidTokens.map((value) => formatInvalid(value)).join(', ')}`
-            : ` (showing first 5: ${invalidTokens
-                .slice(0, 5)
-                .map((value) => formatInvalid(value))
-                .join(', ')}…)`}.
-        </p>
-      )}
-
-      <div
-        className="spectrum-preview"
-        style={gradientStyle}
-        role="img"
-        aria-label={
-          spectrum.length
-            ? `Spectrum preview with ${spectrum.length} wavelength${spectrum.length > 1 ? 's' : ''}.`
-            : 'Empty spectrum preview'
-        }
-      />
-
-      <ul className="rgb-swatches">
-        {spectrum.map(({ wavelength, color }) => {
-          const cssColor = formatRGB(color)
-          return (
-            <li key={wavelength} className="rgb-swatch">
-              <span className="swatch-chip" style={{ backgroundColor: cssColor }} aria-hidden="true" />
-              <div>
-                <p className="swatch-wavelength">{formatWavelength(wavelength)} nm</p>
-                <p className="swatch-rgb">{cssColor}</p>
-                <p className="swatch-alpha">Relative intensity ×{color.alpha.toFixed(2)}</p>
-              </div>
-            </li>
-          )
-        })}
-        {spectrum.length === 0 && (
-          <li className="rgb-swatch empty">Add wavelengths to see their approximate colours.</li>
-        )}
-      </ul>
-    </section>
-  )
-}
-
 function App() {
-  const [selectedSampleId, setSelectedSampleId] = useState(SPECTRA[0].id)
-  const [wavelengthInput, setWavelengthInput] = useState('450, 495, 570, 615, 680')
+  const [dataset, setDataset] = useState(DEFAULT_DATASET)
 
-  const selectedSample = useMemo(
-    () => SPECTRA.find((sample) => sample.id === selectedSampleId) ?? SPECTRA[0],
-    [selectedSampleId]
-  )
+  const { points, warnings } = useMemo(() => parseDataset(dataset), [dataset])
+  const peaks = useMemo(() => detectPeaks(points).slice(0, 5), [points])
+
+  const previewStyle = useMemo(() => {
+    if (points.length === 0) {
+      return {
+        backgroundColor: 'rgba(15, 23, 42, 0.7)',
+        backgroundImage: 'radial-gradient(circle at top, rgba(56, 189, 248, 0.2), transparent 65%)',
+      }
+    }
+
+    const gradientStops = points
+      .map((point) => {
+        const color = wavelengthToRGB(point.wavelength, point.reflectance)
+        const position = ((point.wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * 100
+        return `${formatRGB(color)} ${position.toFixed(1)}%`
+      })
+      .join(', ')
+
+    return {
+      backgroundColor: 'rgba(15, 23, 42, 0.6)',
+      backgroundImage: `linear-gradient(90deg, ${gradientStops})`,
+    }
+  }, [points])
 
   return (
-    <div className="dashboard">
-      <header className="header">
-        <div>
-          <p className="badge">Spectroscopy Lab Notebook</p>
-          <h1>Spectral Results Overview</h1>
-          <p className="lede">
-            Explore recent absorbance scans captured across our pigment and protein studies. Select a
-            sample to review its spectral fingerprints, annotated peaks, and acquisition metadata.
-          </p>
-        </div>
-        <div className="selector">
-          <label htmlFor="sample-selector">Sample</label>
-          <select
-            id="sample-selector"
-            value={selectedSampleId}
-            onChange={(event) => setSelectedSampleId(event.target.value)}
-          >
-            {SPECTRA.map((sample) => (
-              <option key={sample.id} value={sample.id}>
-                {sample.name}
-              </option>
-            ))}
-          </select>
-        </div>
+    <div className="app">
+      <header className="app__header">
+        <h1>RGB Reflectance Spectrum Visualiser</h1>
+        <p>
+          Enter a dataset of reflected wavelengths and their relative reflectance values to explore how the spectrum shifts
+          across the visible range. Peaks highlight where an object reflects the most light.
+        </p>
       </header>
 
-      <main className="content">
-        <section className="panel panel-chart">
-          <div className="panel-header">
-            <h2>{selectedSample.name}</h2>
-            <div className="metadata">
-              <span>{selectedSample.project}</span>
-              <span>Collected {selectedSample.collectedOn}</span>
-              <span>{selectedSample.instrument}</span>
-            </div>
+      <main className="visualiser">
+        <section className="visualiser__inputs" aria-labelledby="dataset-label">
+          <div className="inputs__header">
+            <h2 id="dataset-label">Wavelength dataset</h2>
+            <p>Provide wavelength (nm) and reflectance pairs. One pair per line, separated by spaces or commas.</p>
           </div>
-          <p className="panel-summary">{selectedSample.summary}</p>
-          <SpectralChart
-            spectrum={selectedSample.spectrum}
-            peaks={selectedSample.peaks}
-            title={`${selectedSample.name} absorbance spectrum`}
+          <textarea
+            className="dataset-input"
+            value={dataset}
+            onChange={(event) => setDataset(event.target.value)}
+            rows={10}
+            spellCheck="false"
+            aria-describedby="dataset-hint"
           />
+          <p id="dataset-hint" className="input-hint">
+            Visible wavelengths run from 380&nbsp;nm to 780&nbsp;nm. Reflectance values should be between 0 and 1.
+          </p>
+          {warnings.length > 0 && (
+            <ul className="input-warnings" role="status">
+              {warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+          <div className="spectrum-preview" style={previewStyle} role="img" aria-label="RGB preview of the reflected spectrum" />
         </section>
 
-        <section className="panel panel-details">
-          <h3>Acquisition Details</h3>
-          <dl className="details-grid">
-            <div>
-              <dt>Solvent</dt>
-              <dd>{selectedSample.solvent}</dd>
-            </div>
-            <div>
-              <dt>Temperature</dt>
-              <dd>{selectedSample.temperature}</dd>
-            </div>
-            <div>
-              <dt>Normalization</dt>
-              <dd>{selectedSample.normalization}</dd>
-            </div>
-            <div>
-              <dt>Quality Check</dt>
-              <dd className={`quality quality-${selectedSample.quality.toLowerCase().replace(/\s+/g, '-')}`}>
-                {selectedSample.quality}
-              </dd>
-            </div>
-          </dl>
+        <section className="visualiser__chart">
+          <h2>Reflectance spectrum</h2>
+          <ReflectanceChart points={points} peaks={peaks} />
+        </section>
 
-          <div className="peak-highlights">
-            <h4>Annotated Peaks</h4>
-            <ul>
-              {selectedSample.peaks.map((peak) => (
-                <li key={peak.wavelength}>
-                  <span className="peak-wavelength">{peak.wavelength} nm</span>
-                  <span className="peak-intensity">{peak.intensity.toFixed(2)} a.u.</span>
-                  <p>{peak.assignment}</p>
+        <section className="visualiser__peaks">
+          <h2>Detected reflectance peaks</h2>
+          {peaks.length > 0 ? (
+            <ul className="peaks-list">
+              {peaks.map((peak) => (
+                <li key={`peak-list-${peak.wavelength}-${peak.reflectance}`}>
+                  <span className="peaks-list__wavelength">{peak.wavelength.toFixed(0)} nm</span>
+                  <span className="peaks-list__reflectance">{formatReflectance(peak.reflectance)}</span>
+                  <span className="peaks-list__label">relative reflectance</span>
                 </li>
               ))}
             </ul>
-          </div>
+          ) : (
+            <p className="peaks-empty">Add at least three points to detect peaks.</p>
+          )}
         </section>
-
-        <section className="panel panel-table">
-          <h3>Sample Comparison</h3>
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Sample</th>
-                <th scope="col">λ Range</th>
-                <th scope="col">Dominant Peak</th>
-                <th scope="col">Peak Intensity</th>
-                <th scope="col">Quality</th>
-              </tr>
-            </thead>
-            <tbody>
-              {SPECTRA.map((sample) => {
-                const peak = dominantPeak(sample)
-                return (
-                  <tr key={sample.id} className={sample.id === selectedSample.id ? 'active' : ''}>
-                    <th scope="row">{sample.name}</th>
-                    <td>{formatRange(sample.spectrum)}</td>
-                    <td>{peak ? `${peak.wavelength} nm` : '—'}</td>
-                    <td>{peak ? peak.intensity.toFixed(2) : '—'} a.u.</td>
-                    <td>{sample.quality}</td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </section>
-
-        <RGBSpectrumVisualizer input={wavelengthInput} onChange={setWavelengthInput} />
       </main>
     </div>
   )

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -101,6 +101,60 @@ const xTicks = [
   620, 640, 660, 680, 700
 ]
 
+const VISIBLE_RANGE = { min: 380, max: 780 }
+
+function wavelengthToRGB(wavelength) {
+  if (Number.isNaN(wavelength) || wavelength < VISIBLE_RANGE.min || wavelength > VISIBLE_RANGE.max) {
+    return { r: 0, g: 0, b: 0, alpha: 0 }
+  }
+
+  let red = 0
+  let green = 0
+  let blue = 0
+
+  if (wavelength < 440) {
+    red = -(wavelength - 440) / (440 - 380)
+    blue = 1
+  } else if (wavelength < 490) {
+    green = (wavelength - 440) / (490 - 440)
+    blue = 1
+  } else if (wavelength < 510) {
+    green = 1
+    blue = -(wavelength - 510) / (510 - 490)
+  } else if (wavelength < 580) {
+    red = (wavelength - 510) / (580 - 510)
+    green = 1
+  } else if (wavelength < 645) {
+    red = 1
+    green = -(wavelength - 645) / (645 - 580)
+  } else {
+    red = 1
+  }
+
+  let intensityFactor = 1
+  if (wavelength < 420) {
+    intensityFactor = 0.3 + (0.7 * (wavelength - 380)) / (420 - 380)
+  } else if (wavelength > 700) {
+    intensityFactor = 0.3 + (0.7 * (VISIBLE_RANGE.max - wavelength)) / (VISIBLE_RANGE.max - 700)
+  }
+
+  const normalise = (value) => Math.round(255 * value * intensityFactor)
+
+  return {
+    r: normalise(red),
+    g: normalise(green),
+    b: normalise(blue),
+    alpha: Number(intensityFactor.toFixed(2)),
+  }
+}
+
+function formatRGB({ r, g, b, alpha }) {
+  if (typeof alpha === 'number') {
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  }
+  return `rgb(${r}, ${g}, ${b})`
+}
+
 function SpectralChart({ spectrum, peaks, title }) {
   const width = 640
   const height = 280
@@ -292,8 +346,120 @@ function dominantPeak(sample) {
   }, null)
 }
 
+function RGBSpectrumVisualizer({ input, onChange }) {
+  const { wavelengths, invalidTokens } = useMemo(() => {
+    const tokens = input.split(/[^0-9.]+/)
+    const parsed = tokens
+      .map((token) => Number.parseFloat(token))
+      .filter((value) => !Number.isNaN(value))
+
+    const valid = parsed.filter(
+      (value) => value >= VISIBLE_RANGE.min && value <= VISIBLE_RANGE.max
+    )
+
+    const invalid = parsed.filter(
+      (value) => value < VISIBLE_RANGE.min || value > VISIBLE_RANGE.max
+    )
+
+    return { wavelengths: valid, invalidTokens: invalid }
+  }, [input])
+
+  const spectrum = useMemo(
+    () =>
+      wavelengths.map((wavelength) => ({
+        wavelength,
+        color: wavelengthToRGB(wavelength),
+      })),
+    [wavelengths]
+  )
+
+  const formatWavelength = (value) => (Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1))
+  const formatInvalid = formatWavelength
+
+  const gradientStops = [...spectrum]
+    .sort((a, b) => a.wavelength - b.wavelength)
+    .map(({ wavelength, color }) => {
+      const position = ((wavelength - VISIBLE_RANGE.min) / (VISIBLE_RANGE.max - VISIBLE_RANGE.min)) * 100
+      return `${formatRGB(color)} ${position.toFixed(1)}%`
+    })
+    .join(', ')
+
+  const gradientStyle = spectrum.length
+    ? { backgroundImage: `linear-gradient(90deg, ${gradientStops})` }
+    : { backgroundColor: 'rgba(15, 23, 42, 0.65)' }
+
+  return (
+    <section className="panel panel-rgb" aria-labelledby="rgb-visualizer-heading">
+      <div className="panel-header">
+        <h3 id="rgb-visualizer-heading">RGB Spectrum Visualizer</h3>
+        <p className="panel-description">
+          Enter wavelengths between 380 nm and 780 nm to approximate their contribution to the visible
+          RGB spectrum.
+        </p>
+      </div>
+
+      <label className="rgb-input-label" htmlFor="wavelength-dataset">
+        Wavelength dataset
+      </label>
+      <textarea
+        id="wavelength-dataset"
+        value={input}
+        onChange={(event) => onChange(event.target.value)}
+        className="rgb-input"
+        placeholder="e.g. 450, 495, 570, 615, 680"
+        rows={3}
+      />
+      <p className="input-hint">
+        Separate values with commas, spaces, or line breaks. Values outside the visible range are ignored.
+      </p>
+      {invalidTokens.length > 0 && (
+        <p className="input-warning" role="status">
+          Ignored {invalidTokens.length} value{invalidTokens.length > 1 ? 's' : ''} outside the visible
+          range{invalidTokens.length <= 5
+            ? `: ${invalidTokens.map((value) => formatInvalid(value)).join(', ')}`
+            : ` (showing first 5: ${invalidTokens
+                .slice(0, 5)
+                .map((value) => formatInvalid(value))
+                .join(', ')}…)`}.
+        </p>
+      )}
+
+      <div
+        className="spectrum-preview"
+        style={gradientStyle}
+        role="img"
+        aria-label={
+          spectrum.length
+            ? `Spectrum preview with ${spectrum.length} wavelength${spectrum.length > 1 ? 's' : ''}.`
+            : 'Empty spectrum preview'
+        }
+      />
+
+      <ul className="rgb-swatches">
+        {spectrum.map(({ wavelength, color }) => {
+          const cssColor = formatRGB(color)
+          return (
+            <li key={wavelength} className="rgb-swatch">
+              <span className="swatch-chip" style={{ backgroundColor: cssColor }} aria-hidden="true" />
+              <div>
+                <p className="swatch-wavelength">{formatWavelength(wavelength)} nm</p>
+                <p className="swatch-rgb">{cssColor}</p>
+                <p className="swatch-alpha">Relative intensity ×{color.alpha.toFixed(2)}</p>
+              </div>
+            </li>
+          )
+        })}
+        {spectrum.length === 0 && (
+          <li className="rgb-swatch empty">Add wavelengths to see their approximate colours.</li>
+        )}
+      </ul>
+    </section>
+  )
+}
+
 function App() {
   const [selectedSampleId, setSelectedSampleId] = useState(SPECTRA[0].id)
+  const [wavelengthInput, setWavelengthInput] = useState('450, 495, 570, 615, 680')
 
   const selectedSample = useMemo(
     () => SPECTRA.find((sample) => sample.id === selectedSampleId) ?? SPECTRA[0],
@@ -410,6 +576,8 @@ function App() {
             </tbody>
           </table>
         </section>
+
+        <RGBSpectrumVisualizer input={wavelengthInput} onChange={setWavelengthInput} />
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- add an RGB spectrum visualizer panel that accepts custom wavelength datasets
- convert visible wavelengths into approximate RGB colours and preview them as a gradient and swatches
- style the new inputs, preview, and feedback to match the existing dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7a6d40c88320aca8e523f9a92e70